### PR TITLE
Title goes first for readability

### DIFF
--- a/packages/metadata-editor/MetadataEditor.js
+++ b/packages/metadata-editor/MetadataEditor.js
@@ -55,6 +55,13 @@ class MetadataEditor extends Component {
 
   renderItem($$, field, id) {
     let editorEl = $$('div').addClass('se-field-editor se-field-' + id)
+    
+    const description = field.description
+    if(description && !field.collapse) {
+      editorEl.append(
+        $$('div').addClass('se-description').append(this.getLabel(description))
+      )
+    }
 
     const editor = field.editor
     switch (editor) {
@@ -96,6 +103,13 @@ class MetadataEditor extends Component {
               this.getLabel(field.collapse)
             ).on('click', this._toogleCollapse.bind(this, id))
 
+            const description = field.description
+            if(description) {
+              editorEl.append(
+                $$('div').addClass('se-description').append(this.getLabel(description))
+              )
+            }
+
             editorEl.append(
               label,
               $$(TextPropertyEditor, {
@@ -105,13 +119,6 @@ class MetadataEditor extends Component {
                 withoutBreak: false
               }).addClass('se-editor')
             )
-
-            const description = field.description
-            if(description) {
-              editorEl.append(
-                $$('div').addClass('se-description').append(this.getLabel(description))
-              )
-            }
           }
         } else {
           editorEl.append(
@@ -180,12 +187,7 @@ class MetadataEditor extends Component {
         console.error('Invalid editor for meta property:', id)
     }
 
-    const description = field.description
-    if(description && !field.collapse) {
-      editorEl.append(
-        $$('div').addClass('se-description').append(this.getLabel(description))
-      )
-    }
+    
 
     return editorEl
   }


### PR DESCRIPTION
**Проблема**
Сейчас описание редактируемого метаполя идёт под полем для редактирования, что несколько неправильно, ибо обычно title идёт над инпутом, а не наоборот. Из-за этого выходит небольшая путанница и пользоваться редактором несколько неудобно, ибо постоянно путаешь поля:

![captura de pantalla 2017-11-19 a las 23 37 18](https://user-images.githubusercontent.com/1084409/32995245-d38947e0-cd82-11e7-9660-8d500abac817.png)
_как сейчас_

![captura de pantalla 2017-11-19 a las 23 39 51](https://user-images.githubusercontent.com/1084409/32995255-fb4bc21c-cd82-11e7-9392-088193892ff5.png)
_как будет_